### PR TITLE
Refactor 'manaulDB*' to 'manualDB*'

### DIFF
--- a/metaknowledge/bin/metaknowledgeCLI.py
+++ b/metaknowledge/bin/metaknowledgeCLI.py
@@ -181,23 +181,23 @@ def getWhatToDo(clargs, inRC):
             f.writelines(cites)
         return False
     else:
-        dbName = input("The default manual databse file is called {}, press Enter to use it or type the name of the database you wish to use:\n".format(metaknowledge.journalAbbreviations.manaulDBname))
+        dbName = input("The default manual databse file is called {}, press Enter to use it or type the name of the database you wish to use:\n".format(metaknowledge.journalAbbreviations.manualDBname))
         print("Starting to go over citations, to exit press ctr-C.")
         if dbName == '':
-            dbName = metaknowledge.journalAbbreviations.manaulDBname
+            dbName = metaknowledge.journalAbbreviations.manualDBname
         try:
             for R in inRC:
                 for c in R.get('citations', []):
                     if not hasattr(c, 'journal'):
                         print("{} does not have a journal field".format(c))
-                    elif c.isJournal(manaulDB = dbName, returnDict = 'both'):
+                    elif c.isJournal(manualDB= dbName, returnDict ='both'):
                         print("the journal field of {} is in the database".format(c.journal))
-                    elif c.isJournal(manaulDB = dbName, returnDict = 'both', checkIfExcluded = True):
+                    elif c.isJournal(manualDB= dbName, returnDict ='both', checkIfExcluded = True):
                         print("the journal field of {} is in the database marked to be skipped".format(c.journal))
                     else:
                         addToDB = yesorNo("The citation {} has the journal field:\n{} add as a journal (y/n)? ".format(c, c.journal))
                         if addToDB:
-                            c.addToDB(manaulDB = dbName)
+                            c.addToDB(manualDB= dbName)
                             print("{} added as a journal abbrviation.".format(c.journal))
                         else:
                             c.addToDB(invert = True)

--- a/metaknowledge/citation.py
+++ b/metaknowledge/citation.py
@@ -8,7 +8,7 @@ except ImportError:
 import re
 
 from .mkExceptions import BadCitation
-from .journalAbbreviations import getj9dict, abrevDBname, manaulDBname, addToDB
+from .journalAbbreviations import getj9dict, abrevDBname, manualDBname, addToDB
 
 import metaknowledge
 
@@ -260,7 +260,7 @@ class Citation(collections.abc.Hashable):
         else:
             return retVal
 
-    def isJournal(self, dbname = abrevDBname, manaulDB = manaulDBname, returnDict = 'both', checkIfExcluded = False):
+    def isJournal(self, dbname = abrevDBname, manualDB = manualDBname, returnDict ='both', checkIfExcluded = False):
         """Returns `True` if the `Citation`'s `journal` field is a journal abbreviation from the WOS listing found at [http://images.webofknowledge.com/WOK46/help/WOS/A_abrvjt.html](http://images.webofknowledge.com/WOK46/help/WOS/A_abrvjt.html), i.e. checks if the citation is citing a journal.
 
         **Note**: Requires the [j9Abbreviations](#journalAbbreviations.getj9dict) database file and will raise an error if it cannot be found.
@@ -273,7 +273,7 @@ class Citation(collections.abc.Hashable):
 
         > The name of the downloaded database file, the default is determined at run time. It is recommended that this remain untouched.
 
-        _manaulDB_ : `optional [str]`
+        _manualDB_ : `optional [str]`
 
         > The name of the manually created database file, the default is determined at run time. It is recommended that this remain untouched.
 
@@ -289,7 +289,7 @@ class Citation(collections.abc.Hashable):
         """
         global abbrevDict
         if abbrevDict is None:
-            abbrevDict = getj9dict(dbname = dbname, manualDB = manaulDB, returnDict = returnDict)
+            abbrevDict = getj9dict(dbname = dbname, manualDB = manualDB, returnDict = returnDict)
         if not hasattr(self, 'journal'):
             return False
         elif checkIfExcluded and self.journal:
@@ -329,7 +329,7 @@ class Citation(collections.abc.Hashable):
         else:
             return None
 
-    def addToDB(self, manualName = None, manaulDB = manaulDBname, invert = False):
+    def addToDB(self, manualName = None, manualDB = manualDBname, invert = False):
         """Adds the journal of this Citation to the user created database of journals. This will cause [isJournal()](#Citation.isJournal) to return `True` for this Citation and all others with its `journal`.
 
         **Note**: Requires the [j9Abbreviations](#journalAbbreviations.getj9dict) database file and will raise an error if it cannot be found.
@@ -340,7 +340,7 @@ class Citation(collections.abc.Hashable):
 
         > Default `None`, the full name of journal to use. If not provided the full name will be the same as the abbreviation.
 
-        _manaulDB_ : `optional [str]`
+        _manualDB_ : `optional [str]`
 
         > The name of the manually created database file, the default is determined at run time. It is recommended that this remain untouched.
 
@@ -355,7 +355,7 @@ class Citation(collections.abc.Hashable):
                 d = {self.journal : self.journal}
             else:
                 d = {self.journal : manualName}
-            addToDB(abbr = d, dbname = manaulDB)
+            addToDB(abbr = d, dbname = manualDB)
         except KeyError:
             raise KeyError("This citation does not have a journal field.")
         else:

--- a/metaknowledge/journalAbbreviations/__init__.py
+++ b/metaknowledge/journalAbbreviations/__init__.py
@@ -6,4 +6,4 @@ The citations provided by WOS used abbreviated journal titles instead of the ful
 The other functions of the module are for manually adding and removing abbreviations from the database. It is recommended that this be done with the command-line tool `metaknowledge` instead of with a script.
 """
 
-from .backend import getj9dict, abrevDBname, manaulDBname, addToDB
+from .backend import getj9dict, abrevDBname, manualDBname, addToDB

--- a/metaknowledge/journalAbbreviations/backend.py
+++ b/metaknowledge/journalAbbreviations/backend.py
@@ -9,7 +9,7 @@ from ..mkExceptions import JournalDataBaseError
 
 abrevDBname = "j9Abbreviations"
 
-manaulDBname = "manualj9Abbreviations"
+manualDBname = "manualj9Abbreviations"
 
 def j9urlGenerator(nameDict = False):
     """How to get all the urls for the WOS Journal Title Abbreviations. Each is varies by only a few characters. These are the currently in use urls they may change.
@@ -127,7 +127,7 @@ def updatej9DB(dbname = abrevDBname, saveRawHTML = False):
     except dbm.dumb.error as e:
         raise JournalDataBaseError("Something happened with the database of WOS journal names. To fix this you should delete the 1 to 3 files whose names start with {}. If this doesn't work (sorry), deleteing everything in '{}' and reinstalling metaknowledge should.\nThe error was '{}'".format(dbLoc, os.path.dirname(__file__), e))
 
-def getj9dict(dbname = abrevDBname, manualDB = manaulDBname, returnDict = 'both'):
+def getj9dict(dbname = abrevDBname, manualDB = manualDBname, returnDict ='both'):
     """Returns the dictionary of journal abbreviations mapping to a list of the associated journal names. By default the local database is used. The database is in the file _dbname_ in the same directory as this source file
 
     # Parameters
@@ -136,7 +136,7 @@ def getj9dict(dbname = abrevDBname, manualDB = manaulDBname, returnDict = 'both'
 
     > The name of the downloaded database file, the default is determined at run time. It is recommended that this remain untouched.
 
-    _manaulDB_ : `optional [str]`
+    _manualDB_ : `optional [str]`
 
     > The name of the manually created database file, the default is determined at run time. It is recommended that this remain untouched.
 
@@ -171,8 +171,8 @@ def getj9dict(dbname = abrevDBname, manualDB = manaulDBname, returnDict = 'both'
         return getj9dict(dbname = dbname, manualDB = manualDB, returnDict = returnDict)
     return retDict
 
-def addToDB(abbr = None, dbname = manaulDBname):
-    """Adds _abbr_ to the database of journals. The database is kept separate from the one scraped from WOS, this supersedes it. The database by default is stored with the WOS one and the name is given by `metaknowledge.journalAbbreviations.manaulDBname`. To create an empty database run **addToDB** without an _abbr_ argument.
+def addToDB(abbr = None, dbname = manualDBname):
+    """Adds _abbr_ to the database of journals. The database is kept separate from the one scraped from WOS, this supersedes it. The database by default is stored with the WOS one and the name is given by `metaknowledge.journalAbbreviations.manualDBname`. To create an empty database run **addToDB** without an _abbr_ argument.
 
     # Parameters
 
@@ -182,7 +182,7 @@ def addToDB(abbr = None, dbname = manaulDBname):
 
     _dbname_ : `optional [str]`
 
-    > The name of the database file, default is `metaknowledge.journalAbbreviations.manaulDBname`.
+    > The name of the database file, default is `metaknowledge.journalAbbreviations.manualDBname`.
     """
     dbLoc = os.path.normpath(os.path.dirname(__file__))
     with dbm.dumb.open(dbLoc + '/' + dbname) as db:
@@ -198,8 +198,8 @@ def addToDB(abbr = None, dbname = manaulDBname):
         else:
             raise TypeError("abbr must be a str or dict.")
 
-def excludeFromDB(abbr = None, dbname = manaulDBname):
-    """Marks _abbr_ to be excluded the database of journals. The database is kept separate from the one scraped from WOS, this supersedes it. The database by default is stored with the WOS one and the name is given by `metaknowledge.journalAbbreviations.manaulDBname`. To create an empty database run [**addToDB**()](#journalAbbreviations.addToDB) without an _abbr_ argument.
+def excludeFromDB(abbr = None, dbname = manualDBname):
+    """Marks _abbr_ to be excluded the database of journals. The database is kept separate from the one scraped from WOS, this supersedes it. The database by default is stored with the WOS one and the name is given by `metaknowledge.journalAbbreviations.manualDBname`. To create an empty database run [**addToDB**()](#journalAbbreviations.addToDB) without an _abbr_ argument.
 
     # Parameters
 
@@ -209,7 +209,7 @@ def excludeFromDB(abbr = None, dbname = manaulDBname):
 
     _dbname_ : `optional [str]`
 
-    > The name of the database file, default is `metaknowledge.journalAbbreviations.manaulDBname`.
+    > The name of the database file, default is `metaknowledge.journalAbbreviations.manualDBname`.
     """
     dbLoc = os.path.normpath(os.path.dirname(__file__))
     with dbm.dumb.open(dbLoc + '/' + dbname) as db:


### PR DESCRIPTION
I noticed in various places that 'manual' was spelled 'manaul'. This commit fixes theses typos in code and comments, but it **also changes the API because some typos were in parameter specifications**.

Interested to hear your comments.
